### PR TITLE
make ruby 1.8.7 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 pkg
-
+.rvmrc
 .DS_Store
 **/.DS_Store
 Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg
 
 .DS_Store
 **/.DS_Store
+Gemfile.lock

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use --create --install ree@gatlinggun

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2
+rvm use --create --install ree@gatlinggun

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec

--- a/README.markdown
+++ b/README.markdown
@@ -21,13 +21,24 @@ Then require the library in your code:
 
     require "gatling_gun"
 
-Either way, you will want to setup Gatling Gun as your application loads.  I
-recommend just setting a constant you can then refer to throughout your
-application.  In Rails, I would put the following code in
+Either way, you will want to setup Gatling Gun as your application loads. You
+can configure GatlingGun using a configure block or you can create a
+GatlingGun::Client directly. In Rails, I would put the following code in
 `config/initializers/gatling_gun.rb`.  Setup is easy, just add you SendGrid
 credentials:
 
-    SendGrid = GatlingGun.new("USERNAME", "PASSWORD")
+    GatlingGun.configure do |config|
+      config.username = "USERNAME"
+      config.password = "PASSWORD"
+    end
+
+A client can then be accessed as a method on GatlingGun
+
+    GatlingGun.client
+
+Alternately, you can instantiate a client directly:
+
+    GatlingGun::Client.new("USERNAME", "PASSWORD")
 
 Usage
 -----
@@ -35,29 +46,29 @@ Usage
 The minimal steps to create and send a newsletter would be something like the
 following.  First, you need an identity to send from:
 
-    SendGrid.add_identity( "test", :name    => "Test User",
-                                   :email   => "test@subinterest.com",
-                                   :address => "513 Cinnamon Dr.",
-                                   :city    => "Edmond",
-                                   :state   => "OK",
-                                   :zip     => "73003",
-                                   :country => "USA" )
+    GatlingGun.client.add_identity( "test", :name    => "Test User",
+                                    :email   => "test@subinterest.com",
+                                    :address => "513 Cinnamon Dr.",
+                                    :city    => "Edmond",
+                                    :state   => "OK",
+                                    :zip     => "73003",
+                                    :country => "USA" )
 
 Then you can create a newsletter using that identity:
 
-    SendGrid.add_newsletter( "episode1", :identity => "test",
-                                         :subject  => "Episode 1",
-                                         :text     => "The Text Body",
-                                         :html     => "<h1>The HTML Body</h1>" )
+    GatlingGun.client.add_newsletter( "episode1", :identity => "test",
+                                      :subject  => "Episode 1",
+                                      :text     => "The Text Body",
+                                      :html     => "<h1>The HTML Body</h1>" )
 
 Next you need to create a list of recipients, add some emails to it, and attach 
 that list to the newsletter:
 
-    SendGrid.add_list("subscribers")
-    SendGrid.add_emails( "subscribers", [ { :name  => "James Edward Gray II",
-                                            :email => "james@graysoftinc.com" },
-                                          { :name  => "Admin",
-                                            :email => "admin@graysoftinc.com" } ] )
+    GatlingGun.client.add_list("subscribers")
+    GatlingGun.client.add_emails( "subscribers", [ { :name  => "James Edward Gray II",
+                                                     :email => "james@graysoftinc.com" },
+                                                   { :name  => "Admin",
+                                                     :email => "admin@graysoftinc.com" } ] )
     SendGrid.add_recipients("episode1", "subscribers")
 
 Of course, you could reuse identities and recipient lists for future newsletter
@@ -65,7 +76,7 @@ messages without needing to recreate them.
 
 Finally, you can schedule when to have the message sent:
 
-    SendGrid.add_schedule("episode1", :at => Time.now + 10 * 60)
+    GatlingGun.client.add_schedule("episode1", :at => Time.now + 10 * 60)
 
 That would sent it 10 minutes from now, but you can adjust the time to whenever
 you desire or even leave it out to send now.

--- a/README.markdown
+++ b/README.markdown
@@ -35,29 +35,29 @@ Usage
 The minimal steps to create and send a newsletter would be something like the
 following.  First, you need an identity to send from:
 
-    SendGrid.add_identity( "test", name:    "Test User",
-                                   email:   "test@subinterest.com",
-                                   address: "513 Cinnamon Dr.",
-                                   city:    "Edmond",
-                                   state:   "OK",
-                                   zip:     "73003",
-                                   country: "USA" )
+    SendGrid.add_identity( "test", :name    => "Test User",
+                                   :email   => "test@subinterest.com",
+                                   :address => "513 Cinnamon Dr.",
+                                   :city    => "Edmond",
+                                   :state   => "OK",
+                                   :zip     => "73003",
+                                   :country => "USA" )
 
 Then you can create a newsletter using that identity:
 
-    SendGrid.add_newsletter( "episode1", identity: "test",
-                                         subject:  "Episode 1",
-                                         text:     "The Text Body",
-                                         html:     "<h1>The HTML Body</h1>" )
+    SendGrid.add_newsletter( "episode1", :identity => "test",
+                                         :subject  => "Episode 1",
+                                         :text     => "The Text Body",
+                                         :html     => "<h1>The HTML Body</h1>" )
 
 Next you need to create a list of recipients, add some emails to it, and attach 
 that list to the newsletter:
 
     SendGrid.add_list("subscribers")
-    SendGrid.add_emails( "subscribers", [ { name:  "James Edward Gray II",
-                                            email: "james@graysoftinc.com" },
-                                          { name:  "Admin",
-                                            email: "admin@graysoftinc.com" } ] )
+    SendGrid.add_emails( "subscribers", [ { :name  => "James Edward Gray II",
+                                            :email => "james@graysoftinc.com" },
+                                          { :name  => "Admin",
+                                            :email => "admin@graysoftinc.com" } ] )
     SendGrid.add_recipients("episode1", "subscribers")
 
 Of course, you could reuse identities and recipient lists for future newsletter
@@ -65,7 +65,7 @@ messages without needing to recreate them.
 
 Finally, you can schedule when to have the message sent:
 
-    SendGrid.add_schedule("episode1", at: Time.now + 10 * 60)
+    SendGrid.add_schedule("episode1", :at => Time.now + 10 * 60)
 
 That would sent it 10 minutes from now, but you can adjust the time to whenever
 you desire or even leave it out to send now.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,2 @@
-require "rubygems/package_task"
-
-load(File.join(File.dirname(__FILE__), "gatling_gun.gemspec"))
-Gem::PackageTask.new(SPEC) do |package|
-  # do nothing:  I just need a gem but this block is required
-end
+#!/usr/bin/env rake
+require "bundler/gem_tasks"

--- a/gatling_gun.gemspec
+++ b/gatling_gun.gemspec
@@ -21,7 +21,7 @@ SPEC = Gem::Specification.new do |s|
   for managing and sending newletters.
   END_DESCRIPTION
 
-  s.required_ruby_version     = ">= 1.9.2"
+  s.required_ruby_version     = ">= 1.8.7"
   s.required_rubygems_version = ">= 1.3.7"
 
   s.files         = `git ls-files`.split("\n")

--- a/gatling_gun.gemspec
+++ b/gatling_gun.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/gatling_gun/version', __FILE__)
 
-SPEC = Gem::Specification.new do |gem|
+Gem::Specification.new do |gem|
   gem.name        = "gatling_gun"
   gem.version     = GatlingGun::VERSION
   gem.platform    = Gem::Platform::RUBY

--- a/gatling_gun.gemspec
+++ b/gatling_gun.gemspec
@@ -24,6 +24,8 @@ SPEC = Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 1.8.7"
   s.required_rubygems_version = ">= 1.3.7"
 
+  s.add_dependency 'json'
+
   s.files         = `git ls-files`.split("\n")
   # s.test_files    = `git ls-files -- test/*.rb`.split("\n")
   s.require_paths = %w[lib]

--- a/gatling_gun.gemspec
+++ b/gatling_gun.gemspec
@@ -1,32 +1,24 @@
-DIR     = File.dirname(__FILE__)
-LIB     = File.join(DIR, *%w[lib gatling_gun.rb])
-VERSION = open(LIB) { |lib|
-  lib.each { |line|
-    if v = line[/^\s*VERSION\s*=\s*(['"])(\d\.\d\.\d)\1/, 2]
-      break v
-    end
-  }
-}
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/gatling_gun/version', __FILE__)
 
-SPEC = Gem::Specification.new do |s|
-  s.name        = "gatling_gun"
-  s.version     = VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["James Edward Gray II"]
-  s.email       = ["james@graysoftinc.com"]
-  s.homepage    = "https://github.com/okrb/gatling_gun"
-  s.summary     = "A Ruby library wrapping SendGrid's Newsletter API."
-  s.description = <<-END_DESCRIPTION.gsub(/\s+/, " ").strip
+SPEC = Gem::Specification.new do |gem|
+  gem.name        = "gatling_gun"
+  gem.version     = GatlingGun::VERSION
+  gem.platform    = Gem::Platform::RUBY
+  gem.authors     = ["James Edward Gray II"]
+  gem.email       = ["james@graysoftinc.com"]
+  gem.homepage    = "https://github.com/okrb/gatling_gun"
+  gem.summary     = "A Ruby library wrapping SendGrid's Newsletter API."
+  gem.description = <<-END_DESCRIPTION.gsub(/\s+/, " ").strip
   A library for working with SendGrid's Newsletter API.  The code is intended
   for managing and sending newletters.
   END_DESCRIPTION
 
-  s.required_ruby_version     = ">= 1.8.7"
-  s.required_rubygems_version = ">= 1.3.7"
+  gem.required_ruby_version     = ">= 1.8.7"
+  gem.required_rubygems_version = ">= 1.3.7"
 
-  s.add_dependency 'json'
+  gem.add_dependency 'json'
 
-  s.files         = `git ls-files`.split("\n")
-  # s.test_files    = `git ls-files -- test/*.rb`.split("\n")
-  s.require_paths = %w[lib]
+  gem.files         = `git ls-files`.split("\n")
+  gem.require_paths = %w[lib]
 end

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -8,8 +8,6 @@ require "gatling_gun/api_call"
 require "gatling_gun/response"
 
 class GatlingGun
-  VERSION = "0.0.3"
-
   def initialize(api_user, api_key)
     @api_user = api_user
     @api_key  = api_key

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -5,10 +5,14 @@ require 'time'
 require 'uri'
 require 'ostruct'
 
-require 'gatling_gun/core_ext'
 require 'gatling_gun/api_call'
 require 'gatling_gun/response'
 require 'gatling_gun/client'
+
+# Ruby 1.9 backports
+if RUBY_VERSION.match(/1.8.7/)
+  require 'gatling_gun/core_ext' 
+end
 
 module GatlingGun
   def self.configure

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -9,16 +9,16 @@ require "gatling_gun/response"
 
 class GatlingGun
   VERSION = "0.0.3"
-  
+
   def initialize(api_user, api_key)
     @api_user = api_user
     @api_key  = api_key
   end
-  
+
   ###################
   ### Newsletters ###
   ###################
-  
+
   def add_newsletter(newsletter, details)
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
     %w[identity subject].each do |field|
@@ -48,41 +48,41 @@ class GatlingGun
     parameters[:name] = newsletter if newsletter
     make_api_call("list", parameters)
   end
-  
+
   def delete_newsletter(newsletter)
     make_api_call("delete", name: newsletter)
   end
-  
+
   #############
   ### Lists ###
   #############
-  
+
   def add_list(list, details = { })
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
     make_api_call("lists/add", details.merge(list: list))
   end
-  
+
   def edit_list(list, details = { })
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("lists/edit", details.merge(list: list))
   end
-  
+
   def get_list(list = nil)
     parameters        = { }
     parameters[:list] = list if list
     make_api_call("lists/get", parameters)
   end
   alias_method :list_lists, :get_list
-  
+
   def delete_list(list)
     make_api_call("lists/delete", list: list)
   end
-  
+
   ##############
   ### Emails ###
   ##############
-  
+
   def add_email(list, data)
     json_data = case data
                 when Hash  then data.to_json
@@ -93,7 +93,7 @@ class GatlingGun
     make_api_call("lists/email/add", list: list, data: json_data)
   end
   alias_method :add_emails, :add_email
-  
+
   def get_email(list, emails = nil)
     parameters         = {list: list}
     parameters[:email] = emails if emails
@@ -101,16 +101,16 @@ class GatlingGun
   end
   alias_method :get_emails,  :get_email
   alias_method :list_emails, :get_email
-  
+
   def delete_email(list, emails)
     make_api_call("lists/email/delete", list: list, email: emails)
   end
   alias_method :delete_emails, :delete_email
-  
+
   ################
   ### Identity ###
   ################
-  
+
   def add_identity(identity, details)
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
     %w[name email address city state zip country].each do |field|
@@ -120,31 +120,31 @@ class GatlingGun
     end
     make_api_call("identity/add", details.merge(identity: identity))
   end
-  
+
   def edit_identity(identity, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("identity/edit", details.merge(identity: identity))
   end
-  
+
   def get_identity(identity)
     make_api_call("identity/get", identity: identity)
   end
-  
+
   def list_identities(identity = nil)
     parameters            = { }
     parameters[:identity] = identity if identity
     make_api_call("identity/list", parameters)
   end
-  
+
   def delete_identity(identity)
     make_api_call("identity/delete", identity: identity)
   end
-  
+
   ##################
   ### Recipients ###
   ##################
-  
+
   def add_recipient(newsletter, list)
     make_api_call("recipients/add", name: newsletter, list: list)
   end
@@ -155,39 +155,39 @@ class GatlingGun
   end
   alias_method :get_recipients,  :get_recipient
   alias_method :list_recipients, :get_recipient
-  
+
   def delete_recipient(newsletter, list)
     make_api_call("recipients/delete", name: newsletter, list: list)
   end
   alias_method :delete_recipients, :delete_recipient
-  
+
   #################
   ### Schedules ###
   #################
-  
+
   def add_schedule(newsletter, details = { })
     parameters      = {after: details[:after]}
     parameters[:at] = details[:at].iso8601.sub("T", " ") \
       if details[:at].respond_to? :iso8601
-    if not details[:after].nil? and ( not details[:after].is_a?(Integer) or 
+    if not details[:after].nil? and ( not details[:after].is_a?(Integer) or
                                       details[:after] < 1 )
       fail ArgumentError, "after must be a positive integer"
     end
     make_api_call("schedule/add", parameters.merge(name: newsletter))
   end
-  
+
   def get_schedule(newsletter)
     make_api_call("schedule/get", name: newsletter)
   end
-  
+
   def delete_schedule(newsletter)
     make_api_call("schedule/delete", name: newsletter)
   end
-  
+
   #######
   private
   #######
-  
+
   def make_api_call(action, parameters = { })
     ApiCall.new( action, parameters.merge( api_user: @api_user,
                                            api_key:  @api_key ) ).response

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -3,191 +3,21 @@ require "net/https"
 require "openssl"
 require "time"
 require "uri"
+require 'ostruct'
 
 require "gatling_gun/api_call"
 require "gatling_gun/response"
+require "gatling_gun/client"
 
-class GatlingGun
-  def initialize(api_user, api_key)
-    @api_user = api_user
-    @api_key  = api_key
+module GatlingGun
+  def self.configure
+    config = OpenStruct.new()
+    yield config
+    @@client = Client.new(config.username, config.password)
   end
 
-  ###################
-  ### Newsletters ###
-  ###################
-
-  def add_newsletter(newsletter, details)
-    fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
-    %w[identity subject].each do |field|
-      unless details[field.to_sym] or details[field]
-        fail ArgumentError, "#{field} is a required detail"
-      end
-    end
-    unless details[:text] or details["text"] or
-           details[:html] or details["html"]
-      fail ArgumentError, "either text or html must be provided as a detail"
-    end
-    make_api_call("add", details.merge(:name => newsletter))
-  end
-
-  def edit_newsletter(newsletter, details)
-    fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
-    fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("edit", details.merge(:name => newsletter))
-  end
-
-  def get_newsletter(newsletter)
-    make_api_call("get", :name => newsletter)
-  end
-
-  def list_newsletters(newsletter = nil)
-    parameters        = { }
-    parameters[:name] = newsletter if newsletter
-    make_api_call("list", parameters)
-  end
-
-  def delete_newsletter(newsletter)
-    make_api_call("delete", :name => newsletter)
-  end
-
-  #############
-  ### Lists ###
-  #############
-
-  def add_list(list, details = { })
-    fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
-    make_api_call("lists/add", details.merge(:list => list))
-  end
-
-  def edit_list(list, details = { })
-    fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
-    fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("lists/edit", details.merge(:list => list))
-  end
-
-  def get_list(list = nil)
-    parameters        = { }
-    parameters[:list] = list if list
-    make_api_call("lists/get", parameters)
-  end
-  alias_method :list_lists, :get_list
-
-  def delete_list(list)
-    make_api_call("lists/delete", :list => list)
-  end
-
-  ##############
-  ### Emails ###
-  ##############
-
-  def add_email(list, data)
-    json_data = case data
-                when Hash  then data.to_json
-                when Array then data.map(&:to_json)
-                else            fail ArgumentError,
-                                     "details must be a Hash or Array"
-                end
-    make_api_call("lists/email/add", :list => list, :data => json_data)
-  end
-  alias_method :add_emails, :add_email
-
-  def get_email(list, emails = nil)
-    parameters         = {:list => list}
-    parameters[:email] = emails if emails
-    make_api_call("lists/email/get", parameters)
-  end
-  alias_method :get_emails,  :get_email
-  alias_method :list_emails, :get_email
-
-  def delete_email(list, emails)
-    make_api_call("lists/email/delete", :list => list, :email => emails)
-  end
-  alias_method :delete_emails, :delete_email
-
-  ################
-  ### Identity ###
-  ################
-
-  def add_identity(identity, details)
-    fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
-    %w[name email address city state zip country].each do |field|
-      unless details[field.to_sym] or details[field]
-        fail ArgumentError, "#{field} is a required detail"
-      end
-    end
-    make_api_call("identity/add", details.merge(:identity => identity))
-  end
-
-  def edit_identity(identity, details)
-    fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
-    fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("identity/edit", details.merge(:identity => identity))
-  end
-
-  def get_identity(identity)
-    make_api_call("identity/get", :identity => identity)
-  end
-
-  def list_identities(identity = nil)
-    parameters            = { }
-    parameters[:identity] = identity if identity
-    make_api_call("identity/list", parameters)
-  end
-
-  def delete_identity(identity)
-    make_api_call("identity/delete", :identity => identity)
-  end
-
-  ##################
-  ### Recipients ###
-  ##################
-
-  def add_recipient(newsletter, list)
-    make_api_call("recipients/add", :name => newsletter, :list => list)
-  end
-  alias_method :add_recipients, :add_recipient
-
-  def get_recipient(newsletter)
-    make_api_call("recipients/get", :name => newsletter)
-  end
-  alias_method :get_recipients,  :get_recipient
-  alias_method :list_recipients, :get_recipient
-
-  def delete_recipient(newsletter, list)
-    make_api_call("recipients/delete", :name => newsletter, :list => list)
-  end
-  alias_method :delete_recipients, :delete_recipient
-
-  #################
-  ### Schedules ###
-  #################
-
-  def add_schedule(newsletter, details = { })
-    parameters      = {:after => details[:after]}
-    parameters[:at] = details[:at].iso8601.sub("T", " ") \
-      if details[:at].respond_to? :iso8601
-    if not details[:after].nil? and ( not details[:after].is_a?(Integer) or
-                                      details[:after] < 1 )
-      fail ArgumentError, "after must be a positive integer"
-    end
-    make_api_call("schedule/add", parameters.merge(:name => newsletter))
-  end
-
-  def get_schedule(newsletter)
-    make_api_call("schedule/get", :name => newsletter)
-  end
-
-  def delete_schedule(newsletter)
-    make_api_call("schedule/delete", :name => newsletter)
-  end
-
-  #######
-  private
-  #######
-
-  def make_api_call(action, parameters = { })
-    ApiCall.new( action, parameters.merge( :api_user => @api_user,
-                                           :api_key =>  @api_key ) ).response
+  def self.client
+    @@client
   end
 end
+

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -30,17 +30,17 @@ class GatlingGun
            details[:html] or details["html"]
       fail ArgumentError, "either text or html must be provided as a detail"
     end
-    make_api_call("add", details.merge(name: newsletter))
+    make_api_call("add", details.merge(:name => newsletter))
   end
 
   def edit_newsletter(newsletter, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("edit", details.merge(name: newsletter))
+    make_api_call("edit", details.merge(:name => newsletter))
   end
 
   def get_newsletter(newsletter)
-    make_api_call("get", name: newsletter)
+    make_api_call("get", :name => newsletter)
   end
 
   def list_newsletters(newsletter = nil)
@@ -50,7 +50,7 @@ class GatlingGun
   end
 
   def delete_newsletter(newsletter)
-    make_api_call("delete", name: newsletter)
+    make_api_call("delete", :name => newsletter)
   end
 
   #############
@@ -59,13 +59,13 @@ class GatlingGun
 
   def add_list(list, details = { })
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
-    make_api_call("lists/add", details.merge(list: list))
+    make_api_call("lists/add", details.merge(:list => list))
   end
 
   def edit_list(list, details = { })
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("lists/edit", details.merge(list: list))
+    make_api_call("lists/edit", details.merge(:list => list))
   end
 
   def get_list(list = nil)
@@ -76,7 +76,7 @@ class GatlingGun
   alias_method :list_lists, :get_list
 
   def delete_list(list)
-    make_api_call("lists/delete", list: list)
+    make_api_call("lists/delete", :list => list)
   end
 
   ##############
@@ -90,12 +90,12 @@ class GatlingGun
                 else            fail ArgumentError,
                                      "details must be a Hash or Array"
                 end
-    make_api_call("lists/email/add", list: list, data: json_data)
+    make_api_call("lists/email/add", :list => list, :data => json_data)
   end
   alias_method :add_emails, :add_email
 
   def get_email(list, emails = nil)
-    parameters         = {list: list}
+    parameters         = {:list => list}
     parameters[:email] = emails if emails
     make_api_call("lists/email/get", parameters)
   end
@@ -103,7 +103,7 @@ class GatlingGun
   alias_method :list_emails, :get_email
 
   def delete_email(list, emails)
-    make_api_call("lists/email/delete", list: list, email: emails)
+    make_api_call("lists/email/delete", :list => list, :email => emails)
   end
   alias_method :delete_emails, :delete_email
 
@@ -118,17 +118,17 @@ class GatlingGun
         fail ArgumentError, "#{field} is a required detail"
       end
     end
-    make_api_call("identity/add", details.merge(identity: identity))
+    make_api_call("identity/add", details.merge(:identity => identity))
   end
 
   def edit_identity(identity, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
-    make_api_call("identity/edit", details.merge(identity: identity))
+    make_api_call("identity/edit", details.merge(:identity => identity))
   end
 
   def get_identity(identity)
-    make_api_call("identity/get", identity: identity)
+    make_api_call("identity/get", :identity => identity)
   end
 
   def list_identities(identity = nil)
@@ -138,7 +138,7 @@ class GatlingGun
   end
 
   def delete_identity(identity)
-    make_api_call("identity/delete", identity: identity)
+    make_api_call("identity/delete", :identity => identity)
   end
 
   ##################
@@ -146,18 +146,18 @@ class GatlingGun
   ##################
 
   def add_recipient(newsletter, list)
-    make_api_call("recipients/add", name: newsletter, list: list)
+    make_api_call("recipients/add", :name => newsletter, :list => list)
   end
   alias_method :add_recipients, :add_recipient
 
   def get_recipient(newsletter)
-    make_api_call("recipients/get", name: newsletter)
+    make_api_call("recipients/get", :name => newsletter)
   end
   alias_method :get_recipients,  :get_recipient
   alias_method :list_recipients, :get_recipient
 
   def delete_recipient(newsletter, list)
-    make_api_call("recipients/delete", name: newsletter, list: list)
+    make_api_call("recipients/delete", :name => newsletter, :list => list)
   end
   alias_method :delete_recipients, :delete_recipient
 
@@ -166,22 +166,22 @@ class GatlingGun
   #################
 
   def add_schedule(newsletter, details = { })
-    parameters      = {after: details[:after]}
+    parameters      = {:after => details[:after]}
     parameters[:at] = details[:at].iso8601.sub("T", " ") \
       if details[:at].respond_to? :iso8601
     if not details[:after].nil? and ( not details[:after].is_a?(Integer) or
                                       details[:after] < 1 )
       fail ArgumentError, "after must be a positive integer"
     end
-    make_api_call("schedule/add", parameters.merge(name: newsletter))
+    make_api_call("schedule/add", parameters.merge(:name => newsletter))
   end
 
   def get_schedule(newsletter)
-    make_api_call("schedule/get", name: newsletter)
+    make_api_call("schedule/get", :name => newsletter)
   end
 
   def delete_schedule(newsletter)
-    make_api_call("schedule/delete", name: newsletter)
+    make_api_call("schedule/delete", :name => newsletter)
   end
 
   #######
@@ -189,7 +189,7 @@ class GatlingGun
   #######
 
   def make_api_call(action, parameters = { })
-    ApiCall.new( action, parameters.merge( api_user: @api_user,
-                                           api_key:  @api_key ) ).response
+    ApiCall.new( action, parameters.merge( :api_user => @api_user,
+                                           :api_key =>  @api_key ) ).response
   end
 end

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -1,13 +1,14 @@
-require "json"
-require "net/https"
-require "openssl"
-require "time"
-require "uri"
+require 'json'
+require 'net/https'
+require 'openssl'
+require 'time'
+require 'uri'
 require 'ostruct'
 
-require "gatling_gun/api_call"
-require "gatling_gun/response"
-require "gatling_gun/client"
+require 'gatling_gun/core_ext'
+require 'gatling_gun/api_call'
+require 'gatling_gun/response'
+require 'gatling_gun/client'
 
 module GatlingGun
   def self.configure

--- a/lib/gatling_gun/api_call.rb
+++ b/lib/gatling_gun/api_call.rb
@@ -1,4 +1,4 @@
-class GatlingGun
+module GatlingGun
   class ApiCall
     BASE_URL = "https://sendgrid.com/api/newsletter"
     CA_PATH  = File.join(File.dirname(__FILE__), *%w[.. .. data ca-bundle.crt])

--- a/lib/gatling_gun/api_call.rb
+++ b/lib/gatling_gun/api_call.rb
@@ -2,12 +2,12 @@ class GatlingGun
   class ApiCall
     BASE_URL = "https://sendgrid.com/api/newsletter"
     CA_PATH  = File.join(File.dirname(__FILE__), *%w[.. .. data ca-bundle.crt])
-    
+
     def initialize(action, parameters)
       @action     = action
       @parameters = parameters
     end
-    
+
     def response
       url               = URI.parse("#{BASE_URL}/#{@action}.json")
       http              = Net::HTTP.new(url.host, url.port)

--- a/lib/gatling_gun/client.rb
+++ b/lib/gatling_gun/client.rb
@@ -1,0 +1,188 @@
+module GatlingGun
+  class Client
+    def initialize(api_user, api_key)
+      @api_user = api_user
+      @api_key  = api_key
+    end
+
+    ###################
+    ### Newsletters ###
+    ###################
+
+    def add_newsletter(newsletter, details)
+      fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
+      %w[identity subject].each do |field|
+        unless details[field.to_sym] or details[field]
+          fail ArgumentError, "#{field} is a required detail"
+        end
+      end
+      unless details[:text] or details["text"] or
+             details[:html] or details["html"]
+        fail ArgumentError, "either text or html must be provided as a detail"
+      end
+      make_api_call("add", details.merge(:name => newsletter))
+    end
+
+    def edit_newsletter(newsletter, details)
+      fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
+      fail ArgumentError, "details cannot be empty" if     details.empty?
+      make_api_call("edit", details.merge(:name => newsletter))
+    end
+
+    def get_newsletter(newsletter)
+      make_api_call("get", :name => newsletter)
+    end
+
+    def list_newsletters(newsletter = nil)
+      parameters        = { }
+      parameters[:name] = newsletter if newsletter
+      make_api_call("list", parameters)
+    end
+
+    def delete_newsletter(newsletter)
+      make_api_call("delete", :name => newsletter)
+    end
+
+    #############
+    ### Lists ###
+    #############
+
+    def add_list(list, details = { })
+      fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
+      make_api_call("lists/add", details.merge(:list => list))
+    end
+
+    def edit_list(list, details = { })
+      fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
+      fail ArgumentError, "details cannot be empty" if     details.empty?
+      make_api_call("lists/edit", details.merge(:list => list))
+    end
+
+    def get_list(list = nil)
+      parameters        = { }
+      parameters[:list] = list if list
+      make_api_call("lists/get", parameters)
+    end
+    alias_method :list_lists, :get_list
+
+    def delete_list(list)
+      make_api_call("lists/delete", :list => list)
+    end
+
+    ##############
+    ### Emails ###
+    ##############
+
+    def add_email(list, data)
+      json_data = case data
+                  when Hash  then data.to_json
+                  when Array then data.map(&:to_json)
+                  else            fail ArgumentError,
+                                       "details must be a Hash or Array"
+                  end
+      make_api_call("lists/email/add", :list => list, :data => json_data)
+    end
+    alias_method :add_emails, :add_email
+
+    def get_email(list, emails = nil)
+      parameters         = {:list => list}
+      parameters[:email] = emails if emails
+      make_api_call("lists/email/get", parameters)
+    end
+    alias_method :get_emails,  :get_email
+    alias_method :list_emails, :get_email
+
+    def delete_email(list, emails)
+      make_api_call("lists/email/delete", :list => list, :email => emails)
+    end
+    alias_method :delete_emails, :delete_email
+
+    ################
+    ### Identity ###
+    ################
+
+    def add_identity(identity, details)
+      fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
+      %w[name email address city state zip country].each do |field|
+        unless details[field.to_sym] or details[field]
+          fail ArgumentError, "#{field} is a required detail"
+        end
+      end
+      make_api_call("identity/add", details.merge(:identity => identity))
+    end
+
+    def edit_identity(identity, details)
+      fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
+      fail ArgumentError, "details cannot be empty" if     details.empty?
+      make_api_call("identity/edit", details.merge(:identity => identity))
+    end
+
+    def get_identity(identity)
+      make_api_call("identity/get", :identity => identity)
+    end
+
+    def list_identities(identity = nil)
+      parameters            = { }
+      parameters[:identity] = identity if identity
+      make_api_call("identity/list", parameters)
+    end
+
+    def delete_identity(identity)
+      make_api_call("identity/delete", :identity => identity)
+    end
+
+    ##################
+    ### Recipients ###
+    ##################
+
+    def add_recipient(newsletter, list)
+      make_api_call("recipients/add", :name => newsletter, :list => list)
+    end
+    alias_method :add_recipients, :add_recipient
+
+    def get_recipient(newsletter)
+      make_api_call("recipients/get", :name => newsletter)
+    end
+    alias_method :get_recipients,  :get_recipient
+    alias_method :list_recipients, :get_recipient
+
+    def delete_recipient(newsletter, list)
+      make_api_call("recipients/delete", :name => newsletter, :list => list)
+    end
+    alias_method :delete_recipients, :delete_recipient
+
+    #################
+    ### Schedules ###
+    #################
+
+    def add_schedule(newsletter, details = { })
+      parameters      = {:after => details[:after]}
+      if details[:at].respond_to? :iso8601
+        parameters[:at] = details[:at].iso8601.sub("T", " ")
+      end
+
+      if not details[:after].nil? and ( not details[:after].is_a?(Integer) or
+                                        details[:after] < 1 )
+        fail ArgumentError, "after must be a positive integer"
+      end
+      make_api_call("schedule/add", parameters.merge(:name => newsletter))
+    end
+
+    def get_schedule(newsletter)
+      make_api_call("schedule/get", :name => newsletter)
+    end
+
+    def delete_schedule(newsletter)
+      make_api_call("schedule/delete", :name => newsletter)
+    end
+
+    #######
+    private
+    #######
+
+    def make_api_call(action, parameters = { })
+      ApiCall.new( action, parameters.merge( :api_user => @api_user,
+                                             :api_key =>  @api_key ) ).response
+    end
+  end
+end

--- a/lib/gatling_gun/core_ext.rb
+++ b/lib/gatling_gun/core_ext.rb
@@ -1,0 +1,37 @@
+# backport of 1.9's net/http array value handling in forms
+# http://apidock.com/ruby/Net/HTTPHeader/set_form_data#1105-Backport-from-1-9
+
+require 'cgi'
+module Net
+  module HTTPHeader
+    def set_form_data(params, sep = '&')
+      query = URI.encode_www_form(params)
+      query.gsub!(/&/, sep) if sep != '&'
+      self.body = query
+      self.content_type = 'application/x-www-form-urlencoded'
+    end
+    alias form_data= set_form_data
+  end
+end
+
+module URI
+  def self.encode_www_form(enum)
+    enum.map do |k,v|
+      if v.nil?
+        k
+      elsif v.respond_to?(:to_ary)
+        v.to_ary.map do |w|
+          str = k.is_a?(Symbol) ? k.to_s : k.dup
+          unless w.nil?
+            str << '='
+            str << CGI.escape(w)
+          end
+        end.join('&')
+      else
+        str = k.is_a?(Symbol) ? k.to_s : k.dup
+        str << '='
+        str << CGI.escape(v)
+      end
+    end.join('&')
+  end
+end

--- a/lib/gatling_gun/response.rb
+++ b/lib/gatling_gun/response.rb
@@ -1,7 +1,7 @@
 class GatlingGun
   class Response
     include Enumerable
-    
+
     def initialize(response)
       if response.is_a? Hash
         @success            = false
@@ -13,21 +13,21 @@ class GatlingGun
         @data               = parse(response.body)
       end
     end
-    
+
     attr_reader :http_response_code
-    
+
     def success?
       @success
     end
-    
+
     def error?
       not success?
     end
-    
+
     def error_messages
       Array(self[:errors]) + Array(self[:error])
     end
-    
+
     def [](field)
       case @data
       when Hash
@@ -38,21 +38,21 @@ class GatlingGun
         nil
       end
     end
-    
+
     def each(&iterator)
       if @data.is_a? Enumerable
         @data.each(&iterator)
       end
     end
-    
+
     def empty?
       @data.empty?
     end
-    
+
     #######
     private
     #######
-    
+
     def parse(body)
       JSON.parse(body)
     rescue JSON::JSONError => error

--- a/lib/gatling_gun/response.rb
+++ b/lib/gatling_gun/response.rb
@@ -1,4 +1,4 @@
-class GatlingGun
+module GatlingGun
   class Response
     include Enumerable
 

--- a/lib/gatling_gun/version.rb
+++ b/lib/gatling_gun/version.rb
@@ -1,0 +1,3 @@
+module GatlingGun
+  VERSION = "0.0.3"
+end


### PR DESCRIPTION
Hi,

I had to use this API for a client with some specific requirements of the existing codebase. I figured I'd be a good citizen and open a pull request. Please let me know if there are any changes you object to or any things I'll need to do before you accept this.
### I've introduced several changes:
- removing 1.9-specific syntax in favor of 1.8-compatibility (see: hash syntax)
- pulled in backports for 1.9 fixes
- added a configure block for initializers
- turned the gatling_gun class into a module
- added a client class to hold gatling_gun's previous functionality
- added bundler
- used bundler-style gemspec/rakefile/versioning
- whitespace changes. I know, I know.

I did **not** bump the version. I figured I'd leave that to you. It'll be at least a minor bump, unless you want me to delegate the pre-existing methods to the client object, which I am totally fine with.

:tophat:
:Denny 
