### PR TITLE
Provide fail-fast bang equivalents for each API call

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,3 +69,9 @@ Finally, you can schedule when to have the message sent:
 
 That would sent it 10 minutes from now, but you can adjust the time to whenever
 you desire or even leave it out to send now.
+
+### Bang method calls
+
+By default GatlingGun won't raise an error if SendGrid returns an error.
+
+If you want to raise instead, you can use the bang equivalents (`add_list!`, `add_newsletter!` etc).

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 require "rubygems/package_task"
+require "rake/testtask"
 
 load(File.join(File.dirname(__FILE__), "gatling_gun.gemspec"))
 Gem::PackageTask.new(SPEC) do |package|
   # do nothing:  I just need a gem but this block is required
+end
+
+Rake::TestTask.new do |test|
+  test.libs       << "test"
+  test.test_files =  %w[test/*.rb]
+  test.verbose    =  true
 end

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -5,10 +5,13 @@ require "time"
 require "uri"
 
 require "gatling_gun/api_call"
+require "gatling_gun/bang_method"
 require "gatling_gun/response"
 
-class GatlingGun
+class GatlingGun  
   VERSION = "0.0.3"
+
+  extend GatlingGun::BangMethod
   
   def initialize(api_user, api_key)
     @api_user = api_user
@@ -32,26 +35,31 @@ class GatlingGun
     end
     make_api_call("add", details.merge(name: newsletter))
   end
+  bang_method :add_newsletter
 
   def edit_newsletter(newsletter, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("edit", details.merge(name: newsletter))
   end
+  bang_method :edit_newsletter
 
   def get_newsletter(newsletter)
     make_api_call("get", name: newsletter)
   end
+  bang_method :get_newsletter
 
   def list_newsletters(newsletter = nil)
     parameters        = { }
     parameters[:name] = newsletter if newsletter
     make_api_call("list", parameters)
   end
+  bang_method :list_newsletters
   
   def delete_newsletter(newsletter)
     make_api_call("delete", name: newsletter)
   end
+  bang_method :delete_newsletter
   
   #############
   ### Lists ###
@@ -61,12 +69,14 @@ class GatlingGun
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
     make_api_call("lists/add", details.merge(list: list))
   end
+  bang_method :add_list
   
   def edit_list(list, details = { })
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("lists/edit", details.merge(list: list))
   end
+  bang_method :edit_list
   
   def get_list(list = nil)
     parameters        = { }
@@ -74,10 +84,12 @@ class GatlingGun
     make_api_call("lists/get", parameters)
   end
   alias_method :list_lists, :get_list
+  bang_method :get_list, :list_lists
   
   def delete_list(list)
     make_api_call("lists/delete", list: list)
   end
+  bang_method :delete_list
   
   ##############
   ### Emails ###
@@ -93,6 +105,7 @@ class GatlingGun
     make_api_call("lists/email/add", list: list, data: json_data)
   end
   alias_method :add_emails, :add_email
+  bang_method :add_email, :add_emails
   
   def get_email(list, emails = nil)
     parameters         = {list: list}
@@ -101,11 +114,13 @@ class GatlingGun
   end
   alias_method :get_emails,  :get_email
   alias_method :list_emails, :get_email
+  bang_method :get_email, :get_emails, :list_emails
   
   def delete_email(list, emails)
     make_api_call("lists/email/delete", list: list, email: emails)
   end
   alias_method :delete_emails, :delete_email
+  bang_method :delete_email, :delete_emails
   
   ################
   ### Identity ###
@@ -120,26 +135,31 @@ class GatlingGun
     end
     make_api_call("identity/add", details.merge(identity: identity))
   end
+  bang_method :add_identity
   
   def edit_identity(identity, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("identity/edit", details.merge(identity: identity))
   end
+  bang_method :edit_identity
   
   def get_identity(identity)
     make_api_call("identity/get", identity: identity)
   end
+  bang_method :get_identity
   
   def list_identities(identity = nil)
     parameters            = { }
     parameters[:identity] = identity if identity
     make_api_call("identity/list", parameters)
   end
+  bang_method :list_identities
   
   def delete_identity(identity)
     make_api_call("identity/delete", identity: identity)
   end
+  bang_method :delete_identity
   
   ##################
   ### Recipients ###
@@ -149,17 +169,20 @@ class GatlingGun
     make_api_call("recipients/add", name: newsletter, list: list)
   end
   alias_method :add_recipients, :add_recipient
+  bang_method :add_recipient, :add_recipients
 
   def get_recipient(newsletter)
     make_api_call("recipients/get", name: newsletter)
   end
   alias_method :get_recipients,  :get_recipient
   alias_method :list_recipients, :get_recipient
+  bang_method :get_recipient, :get_recipients, :list_recipients
   
   def delete_recipient(newsletter, list)
     make_api_call("recipients/delete", name: newsletter, list: list)
   end
   alias_method :delete_recipients, :delete_recipient
+  bang_method :delete_recipient, :delete_recipients
   
   #################
   ### Schedules ###
@@ -175,14 +198,17 @@ class GatlingGun
     end
     make_api_call("schedule/add", parameters.merge(name: newsletter))
   end
+  bang_method :add_schedule
   
   def get_schedule(newsletter)
     make_api_call("schedule/get", name: newsletter)
   end
+  bang_method :get_schedule
   
   def delete_schedule(newsletter)
     make_api_call("schedule/delete", name: newsletter)
   end
+  bang_method :delete_schedule
   
   #######
   private

--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -11,8 +11,6 @@ require "gatling_gun/response"
 class GatlingGun  
   VERSION = "0.0.3"
 
-  extend GatlingGun::BangMethod
-  
   def initialize(api_user, api_key)
     @api_user = api_user
     @api_key  = api_key
@@ -35,31 +33,26 @@ class GatlingGun
     end
     make_api_call("add", details.merge(name: newsletter))
   end
-  bang_method :add_newsletter
 
   def edit_newsletter(newsletter, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("edit", details.merge(name: newsletter))
   end
-  bang_method :edit_newsletter
 
   def get_newsletter(newsletter)
     make_api_call("get", name: newsletter)
   end
-  bang_method :get_newsletter
 
   def list_newsletters(newsletter = nil)
     parameters        = { }
     parameters[:name] = newsletter if newsletter
     make_api_call("list", parameters)
   end
-  bang_method :list_newsletters
   
   def delete_newsletter(newsletter)
     make_api_call("delete", name: newsletter)
   end
-  bang_method :delete_newsletter
   
   #############
   ### Lists ###
@@ -69,14 +62,12 @@ class GatlingGun
     fail ArgumentError, "details must be a Hash" unless details.is_a? Hash
     make_api_call("lists/add", details.merge(list: list))
   end
-  bang_method :add_list
   
   def edit_list(list, details = { })
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("lists/edit", details.merge(list: list))
   end
-  bang_method :edit_list
   
   def get_list(list = nil)
     parameters        = { }
@@ -84,12 +75,10 @@ class GatlingGun
     make_api_call("lists/get", parameters)
   end
   alias_method :list_lists, :get_list
-  bang_method :get_list, :list_lists
   
   def delete_list(list)
     make_api_call("lists/delete", list: list)
   end
-  bang_method :delete_list
   
   ##############
   ### Emails ###
@@ -105,7 +94,6 @@ class GatlingGun
     make_api_call("lists/email/add", list: list, data: json_data)
   end
   alias_method :add_emails, :add_email
-  bang_method :add_email, :add_emails
   
   def get_email(list, emails = nil)
     parameters         = {list: list}
@@ -114,13 +102,11 @@ class GatlingGun
   end
   alias_method :get_emails,  :get_email
   alias_method :list_emails, :get_email
-  bang_method :get_email, :get_emails, :list_emails
   
   def delete_email(list, emails)
     make_api_call("lists/email/delete", list: list, email: emails)
   end
   alias_method :delete_emails, :delete_email
-  bang_method :delete_email, :delete_emails
   
   ################
   ### Identity ###
@@ -135,31 +121,26 @@ class GatlingGun
     end
     make_api_call("identity/add", details.merge(identity: identity))
   end
-  bang_method :add_identity
   
   def edit_identity(identity, details)
     fail ArgumentError, "details must be a Hash"  unless details.is_a? Hash
     fail ArgumentError, "details cannot be empty" if     details.empty?
     make_api_call("identity/edit", details.merge(identity: identity))
   end
-  bang_method :edit_identity
   
   def get_identity(identity)
     make_api_call("identity/get", identity: identity)
   end
-  bang_method :get_identity
   
   def list_identities(identity = nil)
     parameters            = { }
     parameters[:identity] = identity if identity
     make_api_call("identity/list", parameters)
   end
-  bang_method :list_identities
   
   def delete_identity(identity)
     make_api_call("identity/delete", identity: identity)
   end
-  bang_method :delete_identity
   
   ##################
   ### Recipients ###
@@ -169,20 +150,17 @@ class GatlingGun
     make_api_call("recipients/add", name: newsletter, list: list)
   end
   alias_method :add_recipients, :add_recipient
-  bang_method :add_recipient, :add_recipients
 
   def get_recipient(newsletter)
     make_api_call("recipients/get", name: newsletter)
   end
   alias_method :get_recipients,  :get_recipient
   alias_method :list_recipients, :get_recipient
-  bang_method :get_recipient, :get_recipients, :list_recipients
   
   def delete_recipient(newsletter, list)
     make_api_call("recipients/delete", name: newsletter, list: list)
   end
   alias_method :delete_recipients, :delete_recipient
-  bang_method :delete_recipient, :delete_recipients
   
   #################
   ### Schedules ###
@@ -198,18 +176,22 @@ class GatlingGun
     end
     make_api_call("schedule/add", parameters.merge(name: newsletter))
   end
-  bang_method :add_schedule
   
   def get_schedule(newsletter)
     make_api_call("schedule/get", name: newsletter)
   end
-  bang_method :get_schedule
   
   def delete_schedule(newsletter)
     make_api_call("schedule/delete", name: newsletter)
   end
-  bang_method :delete_schedule
-  
+
+  ####################
+  ### Bang methods ###
+  ####################
+  extend GatlingGun::BangMethod
+
+  bang_method *instance_methods(false)
+
   #######
   private
   #######

--- a/lib/gatling_gun/bang_method.rb
+++ b/lib/gatling_gun/bang_method.rb
@@ -1,0 +1,13 @@
+class GatlingGun
+  module BangMethod
+    def bang_method(*method_names)
+      method_names.each do |method|
+        define_method("#{method}!") do |*args|
+          response = self.send(method, *args)
+          response.verify!
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/gatling_gun/response.rb
+++ b/lib/gatling_gun/response.rb
@@ -23,6 +23,13 @@ class GatlingGun
     def error?
       not success?
     end
+
+    def verify!
+      # in some cases, a success is returned but with an error message
+      # consider that a failure anyway for bang calls
+      failure = error? || self['error']
+      fail "API call failed - #{self['error']}" if failure
+    end
     
     def error_messages
       Array(self[:errors]) + Array(self[:error])

--- a/test/bang_method_test.rb
+++ b/test/bang_method_test.rb
@@ -33,4 +33,8 @@ class BangMethodTest < Test::Unit::TestCase
     assert Receiver.new.some_api_call!(true).is_a?(FakeResponse)
   end
 
+  def test_actual_use
+    assert GatlingGun.instance_methods.include?(:add_list!)
+  end
+
 end

--- a/test/bang_method_test.rb
+++ b/test/bang_method_test.rb
@@ -1,0 +1,36 @@
+require 'test/unit'
+require 'gatling_gun'
+
+class FakeResponse
+  def initialize(success)
+    @success = success
+  end
+
+  def verify!
+    fail "Error returned!" unless @success
+  end
+end
+
+class Receiver
+  extend GatlingGun::BangMethod
+
+  def some_api_call(success)
+    FakeResponse.new(success)
+  end
+
+  bang_method :some_api_call
+end
+
+class BangMethodTest < Test::Unit::TestCase
+
+  def test_raises_on_failure
+    assert_raise RuntimeError do
+      Receiver.new.some_api_call!(false)
+    end
+  end
+
+  def test_returns_response
+    assert Receiver.new.some_api_call!(true).is_a?(FakeResponse)
+  end
+
+end


### PR DESCRIPTION
A first pull-request after our discussion at #4.

Not completely happy with the current code, but it works though! Feel free to change whatever suits you.

I can blindly call `add_emails!` and I will get an exception if the list does not exist, or `delete_list!` will raise an error if the list does not exist as well.
