### PR TITLE
making data object accessible

### DIFF
--- a/lib/gatling_gun/response.rb
+++ b/lib/gatling_gun/response.rb
@@ -14,7 +14,7 @@ class GatlingGun
       end
     end
     
-    attr_reader :http_response_code
+    attr_reader :http_response_code, :data
     
     def success?
       @success


### PR DESCRIPTION
It's very valuable to be able to access the data response from sendgrid, but currently it is not accessible outside of the instance. Maybe there's a reason for not adding it? 
