### PR TITLE
add count emails for a list

### DIFF
--- a/lib/gatling_gun.rb
+++ b/lib/gatling_gun.rb
@@ -107,6 +107,11 @@ class GatlingGun
   end
   alias_method :delete_emails, :delete_email
 
+  def count_email(list)
+    make_api_call('lists/email/count', list: list)
+  end
+  alias_method :count_emails, :count_email
+
   ################
   ### Identity ###
   ################


### PR DESCRIPTION
add missing api to count emails as seen here https://sendgrid.com/docs/API_Reference/Marketing_Emails_API/emails.html
